### PR TITLE
naming consistency/clarity within src/rail/estimation

### DIFF
--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -42,7 +42,7 @@ class InformPipeline(RailPipeline):
             hdf5_groupname='',
         )
         
-        self.inform_knn = Inform_KNearNeighPDF.build(
+        self.inform_knn = KNearNeighInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_knn.pkl"),
             hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -64,7 +64,7 @@ class InformPipeline(RailPipeline):
         )
         
         """
-        self.inform_delight = Inform_DelightPZ.build(
+        self.inform_delight = DelightInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_delight.hdf5"),
              hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -58,7 +58,7 @@ class InformPipeline(RailPipeline):
         )
 
 
-        self.inform_bpz = Inform_BPZ_lite.build(
+        self.inform_bpz = BPZliteInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_bpz.hdf5"),
              hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -47,7 +47,7 @@ class InformPipeline(RailPipeline):
             hdf5_groupname='',
         )
         
-        self.inform_simplesom = Inform_SimpleSOMSummarizer.build(
+        self.inform_simplesom = MiniSOMInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_simplesom.pkl"),
              hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -52,7 +52,7 @@ class InformPipeline(RailPipeline):
              hdf5_groupname='',
         )
 
-        self.inform_somoclu = Inform_somocluSOMSummarizer.build(
+        self.inform_somoclu = SOMocluInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_somoclu.pkl"),
             hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -69,7 +69,7 @@ class InformPipeline(RailPipeline):
              hdf5_groupname='',
         )
         """
-        self.inform_fzboost = Inform_FZBoost.build(
+        self.inform_fzboost = FlexZBoostInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_FZBoost.hdf5"),
             hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -32,7 +32,7 @@ class InformPipeline(RailPipeline):
         bands = ['u','g','r','i','z','y']
         #band_list = [f'mag_{band}_lsst' for band in bands] + [f'mag_err_{band}_lsst' for band in bands]
         
-        self.inform_trainz = Inform_trainZ.build(
+        self.inform_trainz = TrainZInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_trainz.pkl"),
             hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -37,7 +37,7 @@ class InformPipeline(RailPipeline):
             hdf5_groupname='',
         )
         
-        self.inform_simplenn = Inform_SimpleNN.build(
+        self.inform_simplenn = SklNeurNetInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_simplenn.pkl"),
             hdf5_groupname='',
         )

--- a/src/rail/pipelines/estimation/inform_all.py
+++ b/src/rail/pipelines/estimation/inform_all.py
@@ -74,7 +74,7 @@ class InformPipeline(RailPipeline):
             hdf5_groupname='',
         )
         
-        self.inform_gpz = Inform_GPz_v1.build(
+        self.inform_gpz = GPzInformer.build(
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), "model_gpz.hdf5"),
              hdf5_groupname='',
         )

--- a/src/rail/pipelines/examples/goldenspike/goldenspike.py
+++ b/src/rail/pipelines/examples/goldenspike/goldenspike.py
@@ -106,7 +106,7 @@ class GoldenspikePipeline(RailPipeline):
             hdf5_groupname=''
         )
 
-        self.inform_fzboost = Inform_FZBoost.build(
+        self.inform_fzboost = FlexZBoostInformer.build(
             connections=dict(input=self.table_conv_train.io.output),
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), 'fzboost.pkl'),
             hdf5_groupname=''
@@ -140,7 +140,7 @@ class GoldenspikePipeline(RailPipeline):
             output=os.path.join(namer.get_data_dir(DataType.pdf, PdfType.pz), "output_estimate_knn.hdf5"),
         )
 
-        self.estimate_fzboost = FZBoost.build(
+        self.estimate_fzboost = FlexZBoostEstimator.build(
             connections=dict(
                 input=self.table_conv_test.io.output,
                 model=self.inform_fzboost.io.model,

--- a/src/rail/pipelines/examples/goldenspike/goldenspike.py
+++ b/src/rail/pipelines/examples/goldenspike/goldenspike.py
@@ -162,7 +162,7 @@ class GoldenspikePipeline(RailPipeline):
             )
             self.add_stage(the_eval)
 
-        self.point_estimate_test = PointEstimateHist.build(
+        self.point_estimate_test = PointEstHistSummarizer.build(
             connections=dict(input=self.estimate_bpz.io.output),
             output=os.path.join(namer.get_data_dir(DataType.pdf, PdfType.nz), "output_point_estimate_test.hdf5"),
             single_NZ=os.path.join(namer.get_data_dir(DataType.pdf, PdfType.nz), "single_NZ_point_estimate_test.hdf5"),

--- a/src/rail/pipelines/examples/goldenspike/goldenspike.py
+++ b/src/rail/pipelines/examples/goldenspike/goldenspike.py
@@ -99,7 +99,7 @@ class GoldenspikePipeline(RailPipeline):
             output=os.path.join(namer.get_data_dir(DataType.catalog, CatalogType.degraded), "output_table_conv_test.hdf5"),
         )
 
-        self.inform_knn = Inform_KNearNeighPDF.build(
+        self.inform_knn = KNearNeighInformer.build(
             connections=dict(input=self.table_conv_train.io.output),
             nondetect_val=np.nan,
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), 'knnpz.pkl'),
@@ -130,7 +130,7 @@ class GoldenspikePipeline(RailPipeline):
             output=os.path.join(namer.get_data_dir(DataType.pdf, PdfType.pz), "output_estimate_bpz.hdf5"),
         )
 
-        self.estimate_knn = KNearNeighPDF.build(
+        self.estimate_knn = KNearNeighEstimator.build(
             connections=dict(
                 input=self.table_conv_test.io.output,
                 model=self.inform_knn.io.model,

--- a/src/rail/pipelines/examples/goldenspike/goldenspike.py
+++ b/src/rail/pipelines/examples/goldenspike/goldenspike.py
@@ -168,7 +168,7 @@ class GoldenspikePipeline(RailPipeline):
             single_NZ=os.path.join(namer.get_data_dir(DataType.pdf, PdfType.nz), "single_NZ_point_estimate_test.hdf5"),
         )
 
-        self.naive_stack_test = NaiveStack.build(
+        self.naive_stack_test = NaiveStackSummarizer.build(
             connections=dict(input=self.estimate_bpz.io.output),
             output=os.path.join(namer.get_data_dir(DataType.pdf, PdfType.nz), "output_naive_stack_test.hdf5"),
             single_NZ=os.path.join(namer.get_data_dir(DataType.pdf, PdfType.nz), "single_NZ_naive_stack_test.hdf5"),

--- a/src/rail/pipelines/examples/goldenspike/goldenspike.py
+++ b/src/rail/pipelines/examples/goldenspike/goldenspike.py
@@ -112,7 +112,7 @@ class GoldenspikePipeline(RailPipeline):
             hdf5_groupname=''
         )
 
-        self.inform_bpz = Inform_BPZ_lite.build(
+        self.inform_bpz = BPZliteInformer.build(
             connections=dict(input=self.table_conv_train.io.output),
             model=os.path.join(namer.get_data_dir(DataType.model, ModelType.estimator), 'trained_BPZ.pkl'),
             hdf5_groupname='',
@@ -121,7 +121,7 @@ class GoldenspikePipeline(RailPipeline):
             type_file='',
         )
 
-        self.estimate_bpz = BPZ_lite.build(
+        self.estimate_bpz = BPZliteEstimator.build(
             connections=dict(
                 input=self.table_conv_test.io.output,
                 model=self.inform_bpz.io.model,


### PR DESCRIPTION
## Change Description

This PR (and other concurrent PRs in the other repos) include renamings of modules and stages within `src/rail/estimation` for consistency and transparency to users as outlined in LSSTDESC/rail#37. (Expect a few more PRs to address the smaller set of necessary consistency/clarity changes outside `src/rail/estimation` using the same branch.) 

- [x] My PR includes a link to the issue that I am addressing

I request that multiple reviewers please do not hesitate to suggest changes as needed! The goals are consistency, clarity, and longevity, so if something looks unclear, inconsistent, or insufficiently flexible to accommodate future development, now is the time to make adjustments.

## Solution Description

The following changes were made across all the rail repos, along with updates to the contributing documentation (which should be propagated to the rail python project template so prompts regarding naming are included in future PR checklists).

```
files:
  delightPZ.py --> delight_hybrid.py
  GPz.py --> _gpz_util.py
  knnpz.py --> k_nearneigh.py
  naiveStack.py --> naive_stack.py
  NZDir.py --> nz_dir.py
  pointEstimateHist.py --> point_est_hist.py
  pzflow.py --> pzflow_nf.py
  randomPZ.py --> random_gauss.py
  simpleSOM.py --> minisom_som.py
  sklearn_nn.py --> skl_neurnet.py
  somocluSOM.py --> somoclu_som.py
  trainZ.py --> train_z.py
  varInference.py --> var_inf.py
classes:
  Inform_BPZ_lite --> BPZliteInformer
  BPZ_lite --> BPZliteEstimator
  Inform_CMNNPDF --> CMNNInformer
  CMNNPDF --> CMNNEstimator
  Inform_DelightPZ --> DelightInformer
  delightPZ --> DelightEstimator  
  Inform_GPz_v1 --> GPzInformer
  GPz_v1 --> GPzEstimator
  Inform_FZBoost --> FlexZBoostInformer
  FZBoost --> FlexZBoostEstimator
  Inform_KNearNeighPDF --> KNearNeighInformer
  KNearNeighPDF --> KNearNeighEstimator
  NaiveStack --> NaiveStackSummarizer
  NZDir --> NZDirSummarizer  
  Inform_NZDir --> NZDirInformer
  PointEstimateHist --> PointEstHistSummarizer
  Inform_PZFlowPDF --> PZFlowInformer
  PZFlowPDF --> PZFlowEstimator
  RandomPZ --> RandomGaussEstimator
  Inform_SimpleNN --> SklNeurNetInformer
  SimpleNN --> SklNeurNetEstimator
  Inform_SimpleSOMSummarizer --> MiniSOMInformer
  SimpleSOMSummarizer --> MiniSOMSummarizer
  Inform_somocluSOMSummarizer --> SOMocluInformer
  somocluSOMSummarizer --> SOMocluSummarizer
  Inform_trainZ --> TrainZInformer
  TrainZ --> TrainZEstimator
  VarInferenceStack --> VarInfStackSummarizer   
```

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

Given that we are still pre-v1, I have not explicitly included backward compatibility, but a block of `import X as Y` can be constructed from the above list of changes. I updated the demos and scripts as best I could and checked that the tests still run locally, but it is possible that the smoke tests will uncover something I missed.

### Other Change Checklist
- [X] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have updated unit/End-to-End (E2E) test cases to cover any changes

I fixed some instances of outdated descriptions in the demo notebooks, but others require more substantial editing, e.g. when they describe code that has long since been removed from the demo in question or aspects of the API that have significantly changed since the descriptions were written. The demos require a thorough review before v1 that's out of scope for this series of PRs.