### PR TITLE
Move dependencies (algos) out to rail's pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,30 +23,11 @@ dependencies = [
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
 full = [
-    "pz-rail-astro-tools",
-    "pz-rail-bpz",
-    "pz-rail-cmnn",
-    "pz-rail-dsps",
-    "pz-rail-flexzboost",
-    "pz-rail-fsps",
-    "pz-rail-gpz-v1",
-    "pz-rail-pzflow",
-    "pz-rail-sklearn",
-    "pz-rail-som",
-    "qp-prob[full]",
+    "pz-rail[algos]",
 ]
 
 dev = [
-    "pz-rail-astro-tools",
-    "pz-rail-bpz",
-    "pz-rail-dsps",
-    "pz-rail-flexzboost",
-    "pz-rail-fsps",
-    "pz-rail-gpz-v1",
-    "pz-rail-pzflow",
-    "pz-rail-sklearn",
-    "pz-rail-som",
-    "qp-prob[full]",
+    "pz-rail[algos]",
     "coverage",
     "pytest",
     "pytest-cov", # Used to report total code coverage


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Executes my solution described [in this comment](https://github.com/LSSTDESC/rail/issues/123#issuecomment-1947515940) in issue LSSTDESC/rail#123


## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
