### PR TITLE
Use DNF for specifying selection filters

### DIFF
--- a/src/rail/utils/project.py
+++ b/src/rail/utils/project.py
@@ -134,9 +134,10 @@ class RailProject:
     def get_selection(self, name):
         """ Get a particular selection by name"""
         selections = self.get_selections()
-        selection = selections.get(name, None)
-        if selection is None:
-            raise ValueError(f"selection '{name}' not found in {self}")
+        try:
+            selection = selections[name]
+        except KeyError as msg:
+            raise ValueError(f"selection '{name}' not found in {self}") from msg
         return selection
 
     def get_pzalgorithms(self):


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

This allows us to specify the selection filters using disjunctive normal form; e.g.,
```
Selections:
    gold: [[[LSST_obs_i, <, 25.5]]]
    blend: [[[LSST_obs_i, <, 26.0]]]
    everything: null
```

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
