### PR TITLE
Added flexiblity to be able to run reduce_roman_rubin_data on other c…

### DIFF
--- a/src/rail/cli/pipe_commands.py
+++ b/src/rail/cli/pipe_commands.py
@@ -36,9 +36,9 @@ def build_pipelines(config_file, **kwargs):
 
 @pipe_cli.command()
 @pipe_options.config_file()
-@pipe_options.selection()
 @pipe_options.input_tag()
 @pipe_options.input_selection()
+@pipe_options.selection()
 @pipe_options.run_mode()
 def reduce_roman_rubin(config_file, **kwargs):
     """Reduce the roman rubin simulations for PZ analysis"""

--- a/src/rail/cli/pipe_commands.py
+++ b/src/rail/cli/pipe_commands.py
@@ -37,15 +37,19 @@ def build_pipelines(config_file, **kwargs):
 @pipe_cli.command()
 @pipe_options.config_file()
 @pipe_options.selection()
+@pipe_options.input_tag()
+@pipe_options.input_selection()
 @pipe_options.run_mode()
 def reduce_roman_rubin(config_file, **kwargs):
     """Reduce the roman rubin simulations for PZ analysis"""
     project = RailProject.load_config(config_file)
     selections = project.get_selection_args(kwargs.pop('selection'))
-    iter_kwargs = project.generate_kwargs_iterable(selection=selections)
+    input_selections = kwargs.pop('input_selection')
+    iter_kwargs = project.generate_kwargs_iterable(selection=selections, input_selection=input_selections)
+    input_tag = kwargs.pop('input_tag', 'truth')
     ok = 0
     for kw in iter_kwargs:
-        ok |= reduce_roman_rubin_data(project, **kw, **kwargs)
+        ok |= reduce_roman_rubin_data(project, input_tag, **kw, **kwargs)
     return ok
 
 

--- a/src/rail/cli/pipe_options.py
+++ b/src/rail/cli/pipe_options.py
@@ -15,6 +15,8 @@ __all__ = [
     "flavor",
     "input_dir",
     "input_file",
+    "input_selection",
+    "input_tag",
     "label",
     "maglim",
     "model_dir",
@@ -86,6 +88,22 @@ input_file = PartialOption(
     "--input_file",
     type=click.Path(),
     help="Input file",
+)
+
+
+input_selection = PartialOption(
+    "--input_selection",
+    help="Data selection",
+    multiple=True,
+    default=[None],
+)
+
+
+input_tag = PartialOption(
+    "--input_tag",
+    type=str,
+    default=None,
+    help="Input Catalog tag",
 )
 
 

--- a/src/rail/cli/reduce_roman_rubin_data.py
+++ b/src/rail/cli/reduce_roman_rubin_data.py
@@ -88,6 +88,8 @@ PROJECTIONS = [
 
 def reduce_roman_rubin_data(
     project,
+    input_tag,
+    input_selection,
     selection,
     run_mode=RunMode.bash,
 ):
@@ -117,8 +119,8 @@ def reduce_roman_rubin_data(
                 iteration_vars[i]: iteration_args[i]
                 for i in range(len(iteration_vars))
             }
-
-            source_catalog = project.get_catalog('truth', **iteration_kwargs)
+            input_selection = iteration_kwargs.pop('input_selection', None)
+            source_catalog = project.get_catalog(input_tag, selection=input_selection, **iteration_kwargs)
             sink_catalog = project.get_catalog('reduced', selection=selection, **iteration_kwargs)
             sink_dir = os.path.dirname(sink_catalog)
             if selection_dict:


### PR DESCRIPTION
…atalogs besides the truth catalog

## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
