### PR TITLE
moved cli to src/rail/cli/rail_pipe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
 ]
 
 [project.scripts]
-rail_pipe = "rail.cli.pipe_commands:pipe_cli"
+rail_pipe = "rail.cli.rail_pipe.pipe_commands:pipe_cli"
 
 [build-system]
 requires = [

--- a/src/rail/cli/rail_pipe/__main__.py
+++ b/src/rail/cli/rail_pipe/__main__.py
@@ -1,0 +1,5 @@
+# This file must exist with these contents
+from .pipe_commands import pipe_cli
+
+if __name__ == "__main__":
+    pipe_cli()

--- a/src/rail/cli/rail_pipe/pipe_commands.py
+++ b/src/rail/cli/rail_pipe/pipe_commands.py
@@ -5,8 +5,8 @@ import click
 from rail.core import __version__
 
 from rail.utils.project import RailProject
-from rail.cli import pipe_options, pipe_scripts
-from rail.cli.reduce_roman_rubin_data import reduce_roman_rubin_data
+from rail.cli.rail_pipe import pipe_options, pipe_scripts
+from rail.cli.rail_pipe.reduce_roman_rubin_data import reduce_roman_rubin_data
 
 
 @click.group()
@@ -37,25 +37,6 @@ def build_command(config_file: str, **kwargs: Any) -> int:
     return ok
 
 
-@pipe_cli.command(name="reduce")
-@pipe_options.config_file()
-@pipe_options.input_tag()
-@pipe_options.input_selection()
-@pipe_options.selection()
-@pipe_options.run_mode()
-def reduce_command(config_file: str, **kwargs: Any) -> int:
-    """Reduce the roman rubin simulations for PZ analysis"""
-    project = RailProject.load_config(config_file)
-    selections = project.get_selection_args(kwargs.pop('selection'))
-    input_selections = kwargs.pop('input_selection')
-    iter_kwargs = project.generate_kwargs_iterable(selection=selections, input_selection=input_selections)
-    input_tag = kwargs.pop('input_tag', 'truth')
-    ok = 0
-    for kw in iter_kwargs:
-        ok |= reduce_roman_rubin_data(project, input_tag, **kw, **kwargs)
-    return ok
-
-
 @pipe_cli.command(name="subsample")
 @pipe_options.config_file()
 @pipe_options.selection()
@@ -72,6 +53,30 @@ def subsample_command(config_file: str, **kwargs: Any) -> int:
     ok = 0
     for kw in iter_kwargs:
         ok |= pipe_scripts.subsample_data(project, **kw, **kwargs)
+    return ok
+
+
+@pipe_cli.group(name="reduce")
+def reduce_group() -> None:
+    """Reduce input data for PZ analysis"""
+    
+
+@reduce_group.command(name="roman_rubin")
+@pipe_options.config_file()
+@pipe_options.input_tag()
+@pipe_options.input_selection()
+@pipe_options.selection()
+@pipe_options.run_mode()
+def reduce_roman_rubin(config_file: str, **kwargs: Any) -> int:
+    """Reduce the roman rubin simulations for PZ analysis"""
+    project = RailProject.load_config(config_file)
+    selections = project.get_selection_args(kwargs.pop('selection'))
+    input_selections = kwargs.pop('input_selection')
+    iter_kwargs = project.generate_kwargs_iterable(selection=selections, input_selection=input_selections)
+    input_tag = kwargs.pop('input_tag', 'truth')
+    ok = 0
+    for kw in iter_kwargs:
+        ok |= reduce_roman_rubin_data(project, input_tag, **kw, **kwargs)
     return ok
 
 

--- a/src/rail/cli/rail_pipe/pipe_options.py
+++ b/src/rail/cli/rail_pipe/pipe_options.py
@@ -2,7 +2,7 @@ import enum
 
 import click
 
-from rail.cli.options import (
+from rail.cli.rail.options import (
     EnumChoice,
     PartialOption,
     PartialArgument,

--- a/src/rail/cli/rail_pipe/pipe_scripts.py
+++ b/src/rail/cli/rail_pipe/pipe_scripts.py
@@ -13,7 +13,7 @@ import yaml
 from rail.utils import catalog_utils
 from rail.core.stage import RailPipeline
 from rail.utils.project import RailProject
-from rail.cli.pipe_options import RunMode
+from rail.cli.rail_pipe.pipe_options import RunMode
 
 
 def handle_command(

--- a/src/rail/cli/rail_pipe/reduce_roman_rubin_data.py
+++ b/src/rail/cli/rail_pipe/reduce_roman_rubin_data.py
@@ -7,7 +7,7 @@ import pyarrow.dataset as ds
 import pyarrow.parquet as pq
 from pyarrow import acero
 
-from rail.cli.pipe_options import RunMode
+from rail.cli.rail_pipe.pipe_options import RunMode
 from rail.utils.project import RailProject
 
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Mostly this just moves stuff to the src/rail/cli/rail_pipe directory, which follows more standard practices and so that we can use `python -m rail.cli.rail_pipe` 

This also make a `rail_pipe reduce` sub-command and put the `rail_pipe reduce roman_rubin` command in there.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
